### PR TITLE
Improve documentation and README usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,27 @@ A single object may be observed multiple times — by different sensors, at diff
 
 This library identifies and groups observations that are statistically consistent with originating from the same true object.
 
+```rust
+use clique_fusion::{Observation, Unique, CliqueIndex, CHI2_2D_CONFIDENCE_95};
+
+let obs1 = Observation::builder(0.0, 0.0)
+    .circular_95_confidence_error(5.0)
+    .unwrap()
+    .build();
+let obs2 = Observation::builder(1.0, 0.0)
+    .circular_95_confidence_error(5.0)
+    .unwrap()
+    .build();
+
+let mut index = CliqueIndex::new(CHI2_2D_CONFIDENCE_95);
+index.insert(Unique { id: 1, data: obs1 });
+index.insert(Unique { id: 2, data: obs2 });
+
+for clique in index.cliques() {
+    println!("clique: {:?}", clique);
+}
+```
+
 ---
 
 ## 🔍 Fusion Logic
@@ -80,4 +101,4 @@ See the [C# bindings contributing guide](./csharp/CONTRIBUTING.md) and [the C# b
 
 ## 📜 Licensing
 
-This project is publicly available under the **GNU General Public License v3.0**. It may optionally be distributed under the **MIT license by commercial arrangement.
+This project is available under the terms of the [GNU General Public License v3.0](LICENSE). Commercial users may request an alternative [MIT licence](LICENSING.md).

--- a/benches/gen_data.rs
+++ b/benches/gen_data.rs
@@ -5,7 +5,7 @@ use rand::prelude::*;
 use std::{f64::consts::PI, num::NonZeroUsize};
 use uuid::Uuid;
 
-/// Configuration for generating synthetic observation data for benchmarking.
+/// Configuration for synthetic observations used in benchmarks.
 #[derive(Debug, Clone)]
 pub struct Config {
     /// Maximum offset from reference point for scattered points, in meters.
@@ -24,7 +24,7 @@ pub struct Config {
     pub random_seed: u64,
 }
 
-/// Generate a single point randomly distributed within a circle of a given radius
+/// Returns a random point uniformly distributed within a circle of radius `r`.
 fn generate_scattered_point(radius: f64, rng: &mut impl Rng) -> (f64, f64) {
     fn limit_precision(value: f64) -> f64 {
         (value * 1e10).round() / 1e10
@@ -38,15 +38,13 @@ fn generate_scattered_point(radius: f64, rng: &mut impl Rng) -> (f64, f64) {
     (x, y)
 }
 
-/// Generates a random locations within a circular cluster.
+/// Random points within a circular cluster.
 fn generate_scatter(radius: f64, rng: &mut impl Rng) -> impl Iterator<Item = (f64, f64)> {
     std::iter::repeat_with(move || generate_scattered_point(radius, rng))
 }
 
-/// Iterator over clustered positions. Each cluster contains a fixed number of points, centred around a randomly chosen location.
-///
-/// This is a needlessly complicated approach, but it does mean that clustered positions can
-/// be created entirely lazily, with no intermediate memory allocations.
+/// Iterator over clustered positions. Each cluster contains a fixed number of points
+/// around a randomly chosen centre. Generated lazily without intermediate allocation.
 #[derive(Debug)]
 pub struct ClusteredPositionIter<'a, R: Rng> {
     radius: f64,
@@ -100,9 +98,9 @@ where
     }
 }
 
-/// Generates synthetic observations in local (x, y) coordinates for benchmarking.
+/// Generates synthetic observations for benchmarking.
 ///
-/// The output includes a mix of clustered and scattered observations.
+/// The output mixes clustered and scattered observations.
 #[allow(clippy::missing_panics_doc)]
 #[must_use]
 pub fn generate_observations(config: &Config) -> Vec<Unique<Observation, Uuid>> {

--- a/benches/processing.rs
+++ b/benches/processing.rs
@@ -12,7 +12,7 @@ use uuid::Uuid;
 mod gen_data;
 use gen_data::{Config, generate_observations};
 
-/// Read and parse JSONL file
+/// Generates observations where 5 % are clustered.
 fn five_pct_clustered() -> Vec<Unique<Observation, Uuid>> {
     let config = Config {
         spread: 500.0,

--- a/csharp/src/CliqueFusion/Wrappers/Clique.cs
+++ b/csharp/src/CliqueFusion/Wrappers/Clique.cs
@@ -8,8 +8,7 @@ namespace CliqueFusion
     using System.Collections.Generic;
 
     /// <summary>
-    /// Represents a maximal clique — a group of observation IDs that have been clustered together
-    /// as mutually compatible under the chi-squared threshold.
+    /// A maximal clique of mutually compatible observations.
     /// </summary>
     public record Clique(IReadOnlyList<Guid> ObservationIds);
 }

--- a/csharp/src/CliqueFusion/Wrappers/CliqueIndex.cs
+++ b/csharp/src/CliqueFusion/Wrappers/CliqueIndex.cs
@@ -11,8 +11,7 @@ namespace CliqueFusion
     using CliqueFusion.Native;
 
     /// <summary>
-    /// An index that accumulates observations and extracts maximal cliques from them.
-    /// This class wraps the native Rust-based clique-fusion algorithm via FFI.
+    /// Maintains observations and extracts maximal cliques using the native Rust library.
     /// </summary>
     public sealed class CliqueIndex : IDisposable
     {

--- a/csharp/src/CliqueFusion/Wrappers/CliqueThresholds.cs
+++ b/csharp/src/CliqueFusion/Wrappers/CliqueThresholds.cs
@@ -7,8 +7,7 @@ namespace CliqueFusion
     using CliqueFusion.Native;
 
     /// <summary>
-    /// Provides predefined chi-squared thresholds for common confidence levels,
-    /// useful when constructing a <see cref="CliqueIndex"/>.
+    /// Chi-squared thresholds for common confidence levels.
     /// </summary>
     public static class CliqueThresholds
     {

--- a/csharp/src/CliqueFusion/Wrappers/Observation.cs
+++ b/csharp/src/CliqueFusion/Wrappers/Observation.cs
@@ -7,13 +7,9 @@ namespace CliqueFusion
     using System;
 
     /// <summary>
-    /// Represents a 2D observation with a unique identifier, position, uncertainty (covariance), and optional context.
+    /// 2D observation with position, covariance and optional context.
     ///
-    /// Observations within the same context are never merged into cliques. The context groups
-    /// observations that are known to be distinct — for example, simultaneous detections by a single sensor.
-    ///
-    /// Observations with different contexts, or no context, may be fused into cliques if they are consistent
-    /// under the chi-squared test with the given uncertainty model.
+    /// Observations sharing the same context are never fused into a clique.
     /// </summary>
     public record Observation(
         Guid Id,

--- a/src/cliques.rs
+++ b/src/cliques.rs
@@ -1,19 +1,21 @@
 use std::collections::{HashMap, HashSet};
 
-/// Finds all maximal cliques in an undirected graph using the Bron-Kerbosch algorithm with pivoting.
+/// Returns all maximal cliques of an undirected graph.
 ///
-/// A maximal clique is a complete subgraph (all vertices connected to each other) that cannot
-/// be extended by adding another vertex. This implementation uses pivoting optimization to
-/// reduce the search space significantly.
+/// A maximal clique is a set of vertices that are all pairwise connected and cannot be
+/// extended by adding another vertex. The implementation uses the Bron–Kerbosch algorithm
+/// with pivoting to reduce the search space.
 ///
-/// # Arguments
-/// * `graph` - Adjacency list representation where each vertex maps to its neighbors
-///
-/// # Returns
-/// Vector of all maximal cliques, where each clique is represented as a [`HashSet`] of vertex IDs
-///
-/// # Time Complexity
-/// O(3^(n/3)) worst case, but typically much better with pivoting for sparse graphs
+/// # Example
+/// ```ignore
+/// use std::collections::{HashMap, HashSet};
+/// let graph = HashMap::from([
+///     (0, HashSet::from([1])),
+///     (1, HashSet::from([0])),
+/// ]);
+/// let cliques = find_maximal_cliques(&graph);
+/// assert_eq!(cliques[0], HashSet::from([0,1]));
+/// ```
 pub fn find_maximal_cliques<Id>(graph: &HashMap<Id, HashSet<Id>>) -> Vec<HashSet<Id>>
 where
     Id: Copy + Eq + std::hash::Hash,
@@ -34,13 +36,7 @@ where
     cliques
 }
 
-/// Optimized Bron-Kerbosch implementation with strategic pivoting.
-///
-/// This version includes several optimizations:
-/// - Early termination checks
-/// - Optimal pivot selection to minimize branching
-/// - Efficient set operations using iterators where possible
-/// - Memory-conscious cloning patterns
+/// Bron–Kerbosch search with pivoting and small optimisations.
 fn bron_kerbosch_pivot<Id>(
     graph: &HashMap<Id, HashSet<Id>>,
     r: HashSet<Id>,
@@ -89,15 +85,7 @@ fn bron_kerbosch_pivot<Id>(
     }
 }
 
-/// Selects the optimal pivot vertex to minimize recursive branching.
-///
-/// Strategy: Choose the vertex from P ∪ X with maximum degree in the induced subgraph.
-/// This maximizes the number of vertices we can skip (those connected to the pivot).
-///
-/// # Performance Notes
-/// - Uses iterator chains to avoid temporary allocations
-/// - Caches the union computation for efficiency
-/// - Handles empty sets gracefully
+/// Selects a pivot from `p ∪ x` with the most neighbours to reduce branching.
 fn select_optimal_pivot<Id>(
     graph: &HashMap<Id, HashSet<Id>>,
     p: &HashSet<Id>,


### PR DESCRIPTION
## Summary
- Refine README with usage example and licensing clarification
- Simplify and clarify documentation for core Rust API and FFI
- Polish C# wrapper and benchmark docs

## Testing
- `cargo test`
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a994992d60832aaea4a8089f1970da