### PR TITLE
Allow FFI crate license in cargo-deny

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -4,10 +4,14 @@ confidence-threshold = 1.0
 # Allow only permissive licenses so that this crate can be distributed under a permissive (commercial) license.
 allow = ["MIT", "Unicode-3.0", "Apache-2.0"]
 
-# This library is allowed to be GPL-3.0, but none of it's dependencies are!
-exceptions = [{ allow = ["GPL-3.0"], crate = "clique-fusion" }]
+# This library and its FFI crate are allowed to be GPL-3.0, but none of their dependencies are!
+exceptions = [
+    { allow = ["GPL-3.0"], crate = "clique-fusion" },
+    { allow = ["GPL-3.0"], crate = "clique-fusion-ffi" },
+]
 clarify = [
     { crate = "clique-fusion", expression = "GPL-3.0", license-files = [] },
+    { crate = "clique-fusion-ffi", expression = "GPL-3.0", license-files = [] },
 ]
 
 [advisories]


### PR DESCRIPTION
## Summary
- permit `clique-fusion-ffi` to use the GPL-3.0 license

## Testing
- `cargo fmt --all -- --check`
- `cargo test`
- `cargo clippy`
- `cargo deny check` *(fails: no such command)*
- `cargo install cargo-deny --locked` *(fails: Failure when receiving data from the peer (CONNECT tunnel failed, response 403))*

------
https://chatgpt.com/codex/tasks/task_e_68a997b2e3f4832a99284d3e4473cdcb